### PR TITLE
Fix for Xcode 7.3

### DIFF
--- a/PFTTrackSegment.m
+++ b/PFTTrackSegment.m
@@ -15,12 +15,14 @@
 	if((self = [super init]))
 	{
 		[decoder decodeObject];
-		[decoder decodeObject];
-        [decoder decodeObject];
-		
-		// In seconds
-		durationTime = [[decoder decodeObject] doubleValue];
-		
+		NSNumber *number = [decoder decodeObject];
+		// Fix for Xcode 7.3
+		if (strcmp([number objCType], @encode(double)) == 0) {
+			durationTime = [number doubleValue];
+		} else {
+			[decoder decodeObject];
+			durationTime = [[decoder decodeObject] doubleValue];
+		}
 		[decoder decodeObject];
 	}
 	


### PR DESCRIPTION
The program crashes when parsing trace files generated by Instruments from Xcode 7.3 (beta). It seems Apple made some changes in the binary layout of `PFTTrackSegment` in `UIARun`. I tried to fix it by guessing the layout from the type information. Although it works for me, I wonder whether this is the right way to do it.

Crash log:

```
InstrumentsParser[54550:2549944] *** Terminating app due to uncaught exception 'NSArchiverArchiveInconsistency', reason: '*** Incorrect archive: unexpected byte'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff86988bd2 __exceptionPreprocess + 178
    1   libobjc.A.dylib                     0x00007fff91989dd4 objc_exception_throw + 48
    2   CoreFoundation                      0x00007fff869ef3fd +[NSException raise:format:] + 205
    3   Foundation                          0x00007fff96be95ea _decodeReusedCStringUsingTable + 329
    4   Foundation                          0x00007fff96be9484 -[NSUnarchiver decodeObject] + 73
    5   InstrumentsParser                   0x0000000100001b06 -[PFTTrackSegment initWithCoder:] + 246
    6   Foundation                          0x00007fff96be98a0 _decodeObject_old + 331
    7   Foundation                          0x00007fff96bea470 _decodeValueOfObjCType + 1643
    8   Foundation                          0x00007fff96be9dbc -[NSUnarchiver decodeValueOfObjCType:at:] + 92
    9   Foundation                          0x00007fff96b7d048 -[NSArray(NSArray) initWithCoder:] + 487
    10  Foundation                          0x00007fff96be98a0 _decodeObject_old + 331
    11  InstrumentsParser                   0x00000001000016bc -[XRRun initWithCoder:] + 460
    12  InstrumentsParser                   0x0000000100007516 -[UIARun initWithCoder:] + 86
    13  Foundation                          0x00007fff96be98a0 _decodeObject_old + 331
    14  Foundation                          0x00007fff96be8cfc +[NSUnarchiver unarchiveObjectWithData:] + 64
    15  InstrumentsParser                   0x0000000100003aa3 main + 2563
    16  libdyld.dylib                       0x00007fff89b785ad start + 1
    17  ???                                 0x0000000000000005 0x0 + 5
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```
